### PR TITLE
Fix BoundingBox center calculation and add tests

### DIFF
--- a/caddie/types/__init__.py
+++ b/caddie/types/__init__.py
@@ -1,7 +1,10 @@
 import dataclasses
+from typing import TYPE_CHECKING
 
-from OCC.Core.Bnd import Bnd_Box
 from caddie.ladybug_geometry.geometry3d import Point3D
+
+if TYPE_CHECKING:
+    from OCC.Core.Bnd import Bnd_Box
 
 
 @dataclasses.dataclass
@@ -12,7 +15,7 @@ class BoundingBox:
         self.size = self.__p_max - self.__p_min
 
     @classmethod
-    def from_bnd_box(cls, bb: Bnd_Box):
+    def from_bnd_box(cls, bb: 'Bnd_Box'):
         xmin, ymin, zmin, xmax, ymax, zmax = bb.Get()
         return cls(
             Point3D(
@@ -58,8 +61,10 @@ class BoundingBox:
         return self.__p_max
 
     def center(self):
-        d = (self.__p_min + self.__p_max) * 0.5
-        return Point3D(*d.to_array())
+        min_coords = self.__p_min.as_tuple()
+        max_coords = self.__p_max.as_tuple()
+        center_coords = tuple((mi + ma) * 0.5 for mi, ma in zip(min_coords, max_coords))
+        return Point3D(*center_coords)
 
     def __hash__(self):
         return hash(

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -1,0 +1,11 @@
+from caddie.ladybug_geometry.geometry3d import Point3D
+from caddie.types import BoundingBox
+
+
+def test_bounding_box_center_returns_midpoint():
+    bbox = BoundingBox(Point3D(0, 2, 4), Point3D(10, 4, 8))
+
+    center = bbox.center()
+
+    assert isinstance(center, Point3D)
+    assert center.as_tuple() == (5, 3, 6)


### PR DESCRIPTION
## Summary
- compute BoundingBox center coordinates using Point3D helpers instead of missing to_array
- make OCC dependency optional at import time for BoundingBox
- add regression test covering BoundingBox.center midpoint calculation

## Testing
- PYTHONPATH=. pytest tests/test_bounding_box.py

------
https://chatgpt.com/codex/tasks/task_e_68fa9cbc27cc832bab6170bfd85279ca